### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/handlers/admin_conversations.py
+++ b/handlers/admin_conversations.py
@@ -2001,8 +2001,8 @@ async def store_logo_value(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if settings.store_logo_path and os.path.exists(settings.store_logo_path):
             try:
                 os.remove(settings.store_logo_path)
-            except:
-                pass
+            except Exception as e:
+                print(f"Error deleting old logo {settings.store_logo_path}: {e}")
         
         settings.store_logo_path = file_path
         session.commit()

--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -1259,8 +1259,8 @@ async def admin_confirm_payment_callback(update: Update, context: ContextTypes.D
                     chat_id=user_telegram_id,
                     text=f"✅ Payment Confirmed!\n\n💰 Amount: {format_price(amount)}\n💵 New Balance: {format_price(new_balance)}"
                 )
-            except:
-                pass
+            except Exception as e:
+                print(f"Error notifying user {user_telegram_id}: {e}")
 
         # Go back to payment confirmation menu
         await admin_confirm_order_menu(update, context)
@@ -1308,8 +1308,8 @@ async def admin_cancel_payment_callback(update: Update, context: ContextTypes.DE
                     chat_id=user_telegram_id,
                     text=f"❌ Payment Cancelled\n\n💰 Amount: {format_price(amount)}\n\nYour payment was not confirmed. Please contact support if you believe this is an error."
                 )
-            except:
-                pass
+            except Exception as e:
+                print(f"Error notifying user {user_telegram_id}: {e}")
 
         # Go back to payment cancellation menu
         await admin_cancel_order_menu(update, context)
@@ -1351,8 +1351,8 @@ async def admin_cancel_order_callback(update: Update, context: ContextTypes.DEFA
                     chat_id=user.telegram_id,
                     text=f"❌ Order #{order.id} has been cancelled by admin.\n💰 Refund: {format_price(order.total_amount)}"
                 )
-            except:
-                pass
+            except Exception as e:
+                print(f"Error notifying user {user.telegram_id}: {e}")
 
         # Refresh order details
         await admin_order_detail_callback(update, context)


### PR DESCRIPTION
Replaced 4 bare `except:` clauses in `handlers/admin_handlers.py` and `handlers/admin_conversations.py` with `except Exception as e:` that logs the error.

A bare `except:` clause also catches `SystemExit` and `KeyboardInterrupt`, which prevents users from cleanly stopping the bot (e.g. via Ctrl+C) and can mask real bugs. Replacing it with `except Exception as e:` is the standard Python fix and now prints the error so silent failures don't go unnoticed.

### Before
```python
try:
    os.remove(settings.store_logo_path)
except:
    pass
```

### After
```python
try:
    os.remove(settings.store_logo_path)
except Exception as e:
    print(f"Error deleting old logo {settings.store_logo_path}: {e}")
```

Affected functions:
- `admin_confirm_payment_callback` (handlers/admin_handlers.py)
- `admin_cancel_payment_callback` (handlers/admin_handlers.py)
- `admin_cancel_order_callback` (handlers/admin_handlers.py)
- `store_logo_value` (handlers/admin_conversations.py)

— Sent via @AmSach bot